### PR TITLE
Add XML cleaning to scraper

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,0 +1,26 @@
+name: Scrape Minutes
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run scraper
+        env:
+          HF_USERNAME: ${{ secrets.HF_USERNAME }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python scraper.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Data and logs
+*.log
+*.txt
+*.json
+
+# Environment
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-This is the readme
+# European Parliament Minutes Scraper
+
+This repository contains a simple Python script to scrape the Dutch minutes of the European Parliament and upload them to the Hugging Face Hub.
+
+The crawler starts from a specific table of contents page and walks backwards using the "Vorige" link until it reaches parliamentary term 6. Each minutes page is downloaded, cleaned and pushed as a dataset.
+
+## Requirements
+
+- Python 3.8+
+- See `requirements.txt` for the list of Python dependencies.
+
+## Usage
+
+1. Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set your Hugging Face credentials as environment variables:
+
+```bash
+export HF_USERNAME=<your_username>
+export HF_TOKEN=<your_token>
+```
+
+3. Run the scraper:
+
+```bash
+python scraper.py
+```
+
+The dataset will be created or updated on the Hugging Face Hub under `<HF_USERNAME>/Dutch-European-Parliament-Minutes`.
+
+## GitHub Actions
+
+A workflow is included to run the scraper periodically. Provide the secrets `HF_USERNAME` and `HF_TOKEN` in your repository settings to enable automatic uploads.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
-
+requests
+beautifulsoup4
+lxml
+datasets
+huggingface_hub
+tqdm

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,171 @@
+import os
+import re
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from lxml import etree
+from datasets import Dataset
+from huggingface_hub import HfApi, login
+from tqdm import tqdm
+
+START_TOC_URL = "https://www.europarl.europa.eu/doceo/document/PV-10-2025-06-16-TOC_NL.html"
+HF_USERNAME = os.environ.get("HF_USERNAME", "YOUR_HUGGINGFACE_USERNAME")
+HF_DATASET_NAME = "Dutch-European-Parliament-Minutes"
+HF_REPO_ID = f"{HF_USERNAME}/{HF_DATASET_NAME}"
+
+NAMESPACES = {
+    "text": "http://openoffice.org/2000/text",
+    "table": "http://openoffice.org/2000/table",
+}
+
+
+def collect_minutes_urls(start_url: str):
+    urls = []
+    visited = set()
+    current = start_url
+
+    session = requests.Session()
+    while current and current not in visited:
+        visited.add(current)
+        resp = session.get(current, timeout=20)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "lxml")
+        minutes_url = current.replace("-TOC_NL.html", "_NL.xml")
+        urls.append(minutes_url)
+
+        prev_link = soup.find("a", title="Vorige")
+        if not prev_link or not prev_link.get("href"):
+            break
+        next_url = urljoin(current, prev_link["href"])
+        match = re.search(r"PV-(\d+)-", next_url)
+        if match and int(match.group(1)) < 6:
+            break
+        current = next_url
+    return urls
+
+
+def clean_text(text: str) -> str:
+    """Apply common cleanup rules."""
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"\(The sitting (?:was suspended|opened|closed|ended) at.*?\)", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\(Voting time ended at.*?\)", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\((?:debat|stemming|vraag|interventie)\)", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\(Het woord wordt gevoerd door:.*?\)", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"(\(|\[)\s*(?:(?:[a-zA-Z]{2,3})\s*(?:|\s|))?\s*(?:artikel|rule|punt|item)\s*\d+(?:,\s*lid\s*\d+)?\s*(?:\s+\w+)?\s*(\)|\])", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\[(COM|A)\d+-\d+(/\d+)?\]", "", text)
+    text = re.sub(r"\(?(?:http|https):\/\/[^\s]+?\)", "", text)
+    text = re.sub(r"\[\s*\d{4}/\d{4}\(COD\)\]", "", text)
+    text = re.sub(r"\[\s*\d{4}/\d{4}\(INI\)\]", "", text)
+    text = re.sub(r"\[\s*\d{4}/\d{4}\(RSP\)\]", "", text)
+    text = re.sub(r"\[\s*\d{4}/\d{4}\(IMM\)\]", "", text)
+    text = re.sub(r"\[\s*\d{4}/\d{4}\(NLE\)\]", "", text)
+    text = re.sub(r"\[\s*\d{5}/\d{4}\s*-\s*C\d+-\d+/\d+\s*-\s*\d{4}/\d{4}\(NLE\)\]", "", text)
+    text = re.sub(r"\(\u201cStemmingsuitslagen\u201d, punt \d+\)", "", text)
+    text = re.sub(r"\(de Voorzitter(?: maakt na de toespraak van.*?| weigert in te gaan op.*?| stemt toe| herinnert eraan dat de gedragsregels moeten worden nageleefd| neemt er akte van|)\)", "", text)
+    text = re.sub(r"\(zie bijlage.*?\)", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\(\s*De vergadering wordt om.*?geschorst\.\)", "", text)
+    text = re.sub(r"\(\s*De vergadering wordt om.*?hervat\.\)", "", text)
+    text = re.sub(r"Volgens de \u201ccatch the eye\u201d-procedure wordt het woord gevoerd door.*?\.", "", text)
+    text = re.sub(r"Het woord wordt gevoerd door .*?\.", "", text)
+    text = re.sub(r"De vergadering wordt om \d{1,2}\.\d{2} uur gesloten.", "", text)
+    text = re.sub(r"De vergadering wordt om \d{1,2}\.\d{2} uur geopend.", "", text)
+    text = re.sub(r"Het debat wordt gesloten.", "", text)
+    text = re.sub(r"Stemming:.*?\.", "", text)
+    text = re.sub(r"\s{2,}", " ", text).strip()
+    return text
+
+
+def extract_dutch_text_from_xml(xml_content: bytes) -> str | None:
+    """Parse XML minutes and return cleaned Dutch text."""
+    try:
+        parser = etree.XMLParser(recover=True, ns_clean=True)
+        root = etree.fromstring(xml_content, parser=parser)
+    except etree.XMLSyntaxError:
+        return None
+
+    dutch_texts = []
+    relevant_sections = [
+        "PV.Other.Text",
+        "PV.Debate.Text",
+        "PV.Vote.Text",
+        "PV.Sitting.Resumption.Text",
+        "PV.Approval.Text",
+        "PV.Agenda.Text",
+        "PV.Sitting.Closure.Text",
+    ]
+
+    for section in relevant_sections:
+        xpath_query = f"//{section}//text:p"
+        for p_tag in root.xpath(xpath_query, namespaces=NAMESPACES):
+            text_content = p_tag.xpath("string()").strip()
+            if not text_content:
+                continue
+            if p_tag.xpath("ancestor::table:table", namespaces=NAMESPACES):
+                continue
+            if (
+                p_tag.xpath("./Orator.List.Text", namespaces=NAMESPACES)
+                or p_tag.xpath("./Attendance.Participant.Name", namespaces=NAMESPACES)
+            ):
+                name_list_text = p_tag.xpath(
+                    "string(./Orator.List.Text)", namespaces=NAMESPACES
+                ).strip()
+                if (
+                    len(text_content) < 100
+                    and name_list_text
+                    and name_list_text == text_content
+                ):
+                    continue
+            if len(text_content) < 20 and not re.search(r"[a-zA-Z]{5,}", text_content):
+                continue
+            dutch_texts.append(text_content)
+
+    final_text = clean_text("\n".join(dutch_texts))
+    if final_text and len(final_text) > 50:
+        return final_text
+    return None
+
+
+def fetch_minutes_text(url: str, session: requests.Session) -> str | None:
+    resp = session.get(url, timeout=20)
+    resp.raise_for_status()
+    return extract_dutch_text_from_xml(resp.content)
+
+
+def scrape() -> list:
+    toc_urls = collect_minutes_urls(START_TOC_URL)
+    data = []
+    with requests.Session() as session:
+        for url in tqdm(toc_urls, desc="Scraping minutes"):
+            try:
+                text = fetch_minutes_text(url, session)
+                if text:
+                    data.append({"URL": url, "text": text, "source": "European Parliament Minutes"})
+            except Exception as e:
+                print(f"Failed to scrape {url}: {e}")
+    return data
+
+
+def push_dataset(records):
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        print("HF_TOKEN not provided")
+        return
+    login(token=token)
+    ds = Dataset.from_list(records)
+    api = HfApi()
+    api.create_repo(repo_id=HF_REPO_ID, repo_type="dataset", exist_ok=True)
+    ds.push_to_hub(HF_REPO_ID, private=False)
+
+
+def main():
+    records = scrape()
+    if records:
+        push_dataset(records)
+    else:
+        print("No data scraped")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- clean minutes XML using lxml and regex rules
- skip records without parsed text
- convert TOC links to XML files when scraping

## Testing
- `python -m py_compile scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68517060347c8329aaa330ea30bddc1d